### PR TITLE
CDG-6999  Changes to improve dailydigst parsing with regards to grouping

### DIFF
--- a/locator.egg-info/SOURCES.txt
+++ b/locator.egg-info/SOURCES.txt
@@ -1,3 +1,4 @@
+setup.py
 locator/__init__.py
 locator/congressionalrecordindex.py
 locator/dailydigest.py

--- a/locator/__init__.py
+++ b/locator/__init__.py
@@ -134,7 +134,7 @@ def output(input_line, prefix=None, postfix=None, outf=sys.stdout):
     prefix is printed prior to input_line, postfix is print after input_line.
     '''
     if not postfix:
-        postfix = '\n'
+        postfix = ''
     _output(input_line, prefix, postfix, outf)
 
 def _output(input_line, prefix=None, postfix=None, outf=sys.stdout):

--- a/locator/dailydigest.py
+++ b/locator/dailydigest.py
@@ -46,7 +46,7 @@ class DailyDigestInputParser(InputParser):
         b"I15": {'start': "<p>",                 'end': "<br>",                'grid': b"G1", },
         b"I21": {'start': "<p>",                 'end': "",                    'grid': b"G1", },
         b"I29": {'start': "<p><strong>",         'end': "</strong><br>",       'grid': b"G1", },
-        b"I30": {'start': "<p><strong>",         'end': "</strong>",           'grid': b"G1", },
+        b"I30": {'start': "<br /><p><strong>",         'end': "</strong>",           'grid': b"G1", },
         b"I31": {'start': "<strong>",            'end': "</strong>",           'grid': b"G1", },
         b"I40": {'start': "<em>",                'end': "</em>",               'grid': b"G1", },
         b"I41": {'start': "<strong><em>",        'end': "</em></strong>",      'grid': b"G2", },

--- a/locator/tests/dtestPageWhitespace.rec
+++ b/locator/tests/dtestPageWhitespace.rec
@@ -1,0 +1,1 @@
+Z! EXT .000 ...DIGEST PERSONAL COMPUTER\J\059060-A06SE9-000-*****-*****-Payroll No.: 16926 -Name: mc -Folios: S1-S2 -Date: 09/06/2016 -Subformat:   F0627 I32September 6, 2016I33September 6, 2016I01Tuesday, September 6, 2016¨D870­I02Daily DigestI03HIGHLIGHTS I30Petitions and Memorials:LPagesS5276ÿ0977I30Additional Cosponsors:LPagesS5279ÿ0981

--- a/locator/tests/test_congressional_record_index.py
+++ b/locator/tests/test_congressional_record_index.py
@@ -81,7 +81,7 @@ class CongressionalRecordIndexLocatorTest(unittest.TestCase):
         for output_tuple in parser.parse():
             name, output = output_tuple
             self.assertEqual(
-            "<h2>\nRemarks in House\n\n</h2>\n<p>\nAnderson, Michael and Kelly: Ryan Purcell Foundation Tim O'Neil Good Samaritan Award recipients, E1369 [28SE]\n\n</p>\n<p>\nDoctor, Don and Patty Jackson: Ryan Purcell Foundation Michael J. Diggins Community Service Award recipients, E1368 [28SE]\n</p>\n",
+            "<h2>Remarks in House\n</h2><p>Anderson, Michael and Kelly: Ryan Purcell Foundation Tim O'Neil Good Samaritan Award recipients, E1369 [28SE]\n</p><p>Doctor, Don and Patty Jackson: Ryan Purcell Foundation Michael J. Diggins Community Service Award recipients, E1368 [28SE]</p>",
                 output.read())
 
     def test_split_stanza(self):
@@ -110,12 +110,12 @@ class CongressionalRecordIndexLocatorTest(unittest.TestCase):
             if num == 0:
                 #self.assertEqual(name, b'RYAN-PURCELL-FOUNDATION.htm')
                 self.assertEqual(
-                    "<h2>\nRemarks in House\n\n</h2>\n<p>\nAnderson, Michael and Kelly: Ryan Purcell Foundation Tim O'Neil Good Samaritan Award recipients, E1369 [28SE]\n\n</p>\n<p>\nDoctor, Don and Patty Jackson: Ryan Purcell Foundation Michael J. Diggins Community Service Award recipients, E1368 [28SE]\n</p>\n",
+                    "<h2>Remarks in House\n</h2><p>Anderson, Michael and Kelly: Ryan Purcell Foundation Tim O'Neil Good Samaritan Award recipients, E1369 [28SE]\n</p><p>Doctor, Don and Patty Jackson: Ryan Purcell Foundation Michael J. Diggins Community Service Award recipients, E1368 [28SE]</p>",
                     iostream.read())
             else:
                 #self.assertEqual(name, b'Second-stanza-RYAN-PURCELL-FOUNDATION.htm')
                 self.assertEqual(
-                    "<h2>\nRemarks in House\n\n</h2>\n<p>\nAnderson, Michael and Kelly: Ryan Purcell Foundation Tim O'Neil Good Samaritan Award recipients, E1369 [28SE]\n\n</p>\n<p>\nDoctor, Don and Patty Jackson: Ryan Purcell Foundation Michael J. Diggins Community Service Award recipients, E1368 [28SE]\n</p>\n",
+                    "<h2>Remarks in House\n</h2><p>Anderson, Michael and Kelly: Ryan Purcell Foundation Tim O'Neil Good Samaritan Award recipients, E1369 [28SE]\n</p><p>Doctor, Don and Patty Jackson: Ryan Purcell Foundation Michael J. Diggins Community Service Award recipients, E1368 [28SE]</p>",
                     iostream.read())
 
 

--- a/locator/tests/test_dailydigest.py
+++ b/locator/tests/test_dailydigest.py
@@ -1,0 +1,25 @@
+import unittest
+import logging
+from locator.dailydigest import DailyDigestInputParser
+from locator.parser import LocatorParser, OutputParser
+logger = logging.getLogger(__name__)
+
+
+class DailydigestTest(unittest.TestCase):
+
+    def test_all(self):
+        '''Check to see if a mini daily digest file is able to be converted.'''
+        import os
+        TESTDATA_FILENAME = os.path.join(os.path.dirname(__file__), 'dtestPageWhitespace.rec')
+
+        final = ""
+        with open (TESTDATA_FILENAME, "rb") as data:
+            parser = LocatorParser(inputdata=data,
+                                inputparser=DailyDigestInputParser(),
+                                outputparser=OutputParser())
+            for outputstream in parser.parse():
+                outputstream.seek(0)
+                final="%s%s" % (final , outputstream.read())
+            print (final)
+        self.assertEqual(final,  '''<html><h3><em>Tuesday, September 6, 2016<br /></em></h3><center><h1>Daily Digest<br /></h1></center><h4>HIGHLIGHTS <br /></h4><br /><p><strong>Petitions and Memorials:<br /></strong><pre><strong>Pages S5276&ndash;77<br /></strong></pre><br /><p><strong>Additional Cosponsors:<br /></strong><pre><strong>Pages S5279&ndash;81
+<br /></html>''')

--- a/locator/tests/test_makelines.py
+++ b/locator/tests/test_makelines.py
@@ -197,4 +197,4 @@ class LocatorTest(unittest.TestCase):
             contents = out_io.getvalue()
             self.assertEqual(
                 contents,
-                "<span class='bell-I67H dailydigest-extension'>\n")
+                "<span class='bell-I67H dailydigest-extension'>")

--- a/test_dailydigest.py
+++ b/test_dailydigest.py
@@ -1,0 +1,33 @@
+import sys
+from locator.parser import LocatorParser,OutputParser
+from locator.dailydigest import DailyDigestInputParser
+import logging
+def main():
+
+    logging.basicConfig(level=logging.DEBUG,
+                        format='%(asctime)s %(name)-12s %(levelname)-8s {%(pathname)s:%(lineno)d} %(message)s',
+                                            datefmt='%m-%d %H:%M',
+                                            )
+
+    logger = logging.getLogger(__name__)
+    logger.debug("foo")
+
+    inputdatafile= sys.argv[1]
+    with open ( inputdatafile, "rb" ) as inputdata:
+        try:
+            parser = LocatorParser(inputdata=inputdata,
+                                inputparser=DailyDigestInputParser(),
+                                outputparser=OutputParser()
+                                )
+            output = parser.parse()
+        except Exception as e:
+            logger.exception(e)
+            raise e
+        for outputstream in output:
+            # fyi, there should normally only be one stream in our output.
+            # ensure that you start from the begining of the output
+            outputstream.seek(0)
+            print (outputstream.read())
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
section headers and page numbers together.  Instead of always adding a
newline to the end of every line we more closely track with what appears
to be part of the printed GPO output.