### PR TITLE
a acute and e acute are handled properly.  

### DIFF
--- a/locator/__init__.py
+++ b/locator/__init__.py
@@ -28,7 +28,7 @@ MAPPING = {b'\x009': b' ',  # tab to space
            b'\x5f': b'--' , # replace underbar with double hyphen??? TODO: check
            b'\x18': b'<br />' , # \x18 CANCEL-> <br/> ?
            b'\x1a': b'<br />' , # \x1a Substitute -> <br/> ?
-           #b'\xff': b'&yuml;' , #  y with .. over it.
+           #b'\xff': b'&yuml;' , #  y with .. dots over it. used to indicate accents
 }
 
 
@@ -184,7 +184,7 @@ ESCAPE_SEQUENCES = {#esc    # action
                              b'c':  {'desc' :'acute' ,      'html':b'c&#180;' }, #TODO check
                              b's':  {'desc' :'acute' ,      'html':b's&#180;' }, #TODO check
 
-                             b'a':  {'desc' :'acute' ,      'html':b'&#223;' },
+                             b'a':  {'desc' :'acute' ,      'html':b'&#225;' },
                              b'e':  {'desc' :'acute' ,      'html':b'&#233;' },
                              b'i':  {'desc' :'acute' ,      'html':b'&#237;' },
                              b'o':  {'desc' :'acute' ,      'html':b'&#243;' },
@@ -203,6 +203,7 @@ def process_escapes(found, orig_line, current_start, current_line, current_grid 
     '''
     logger.debug("process esc:%s", current_line)
     output = current_line
+    logger.debug("Current_grid[1:]:%s ", current_grid[1:])
     if int(current_grid[1:]) <= 4:
         replace = found.group('replace')
         esc = found.group('esc')

--- a/locator/tests/accents.rec
+++ b/locator/tests/accents.rec
@@ -1,0 +1,1 @@
+Z! EXT .000 ...DIGEST          PERSONAL COMPUTER\J\059060-A15SE9-000-*****-*****-Payroll No.:  -Name: c3 -Folios: 1-2 -Date: 09/15/16 -Subformat:   F0627 I32September 15, 2016I33September 15, 2016I01Thursday, September 15, 2016¨D929­ PLujaÿAE1n, Ben

--- a/locator/tests/test_accents.py
+++ b/locator/tests/test_accents.py
@@ -1,0 +1,44 @@
+import unittest
+import logging
+from locator.dailydigest import DailyDigestInputParser
+from locator.parser import LocatorParser, OutputParser
+from locator import process_escapes_in_line
+logger = logging.getLogger(__name__)
+
+
+class AccentsTest(unittest.TestCase):
+
+    def _load_and_convert(self, filename):
+        '''Check to see if a mini daily digest file is able to be converted.'''
+        import os
+        TESTDATA_FILENAME = os.path.join(os.path.dirname(__file__), filename)
+
+        final = ""
+        with open (TESTDATA_FILENAME, "rb") as data:
+            parser = LocatorParser(inputdata=data,
+                                inputparser=DailyDigestInputParser(),
+                                outputparser=OutputParser())
+            for outputstream in parser.parse():
+                outputstream.seek(0)
+                final="%s%s" % (final , outputstream.read())
+            print (final)
+        return final
+
+    def test_process_aacute(self):
+        ''' a acute '''
+        line = b'Luja\xffAE1n, Ben'
+        current_grid = b'G2'
+        aline= process_escapes_in_line(line, current_grid)
+        self.assertEqual( b"Luj&#225;n, Ben", aline)
+
+    def test_process_eecute(self):
+        ''' e acute '''
+        line = b'e\xffAE1'
+        current_grid = b'G2'
+        aline= process_escapes_in_line(line, current_grid)
+        self.assertEqual( b"&#233;", aline)
+
+    def test_accent_1(self):
+        '''Test to convert accents'''
+        final = self._load_and_convert('accents.rec')
+        self.assertEqual(final,  '''<html><h3><em>Thursday, September 15, 2016 <br /></em></h3>Luj&#225;n, Ben<br />\n<br /></html>''')


### PR DESCRIPTION
Support a acute and e acute accents in conversions.
Need to do a future enhancement of ensuring our most commonly used characters are
supported and in the unit tests.